### PR TITLE
Fix broken video on mobile by turning it off

### DIFF
--- a/src/html/shared/home/testimonial-tmnf.html
+++ b/src/html/shared/home/testimonial-tmnf.html
@@ -22,7 +22,7 @@
                 </cite>
               </div>
               <div class="column col-xs-12 col-sm-4 col-3 testimonial-cite--right">
-                <img src="images/tm_america_symbol.png" height="48px" />
+                <img src="images/tm_america_symbol.png" height="48" alt="Tokio Marine" />
               </div>
             </div>
           </div>

--- a/src/javascripts/app.js
+++ b/src/javascripts/app.js
@@ -28,6 +28,7 @@ $(document).ready(function () {
       vid.pause();
     }
   });
+
 });
 
 // Optimized scroll listener

--- a/src/stylesheets/components/_hero.scss
+++ b/src/stylesheets/components/_hero.scss
@@ -21,12 +21,18 @@
     left: -300%;
     width: 600%;
     height: 100%;
+    z-index: 1;
+    display: none;
+
+    @media (min-width: 576px) {
+      display: block;
+    }
 
     // When aspect ratio is wider
     @media (min-aspect-ratio: 16/9) {
       height: 300%;
       top: -100%;
-      width: 110%;
+      width: 150%;
       left: -5%;
     }
 
@@ -35,12 +41,12 @@
       height: 300%;
       top: -100%;
     }
-
+    
     @media (max-aspect-ratio: 11/9) {
       width: 600%;
       left: -200%;
     }
-
+    
     @media (max-aspect-ratio: 5/9) {
       width: 600%;
       left: -200%;


### PR DESCRIPTION
There's some issue in mobile browsers where they're not displaying the html5 video element, despite existing browser support. Turning it off for small screens seems to solve the issue and is more performant anyway.